### PR TITLE
mark convert's second parameter as optional for typescript definition generation

### DIFF
--- a/src/converter.js
+++ b/src/converter.js
@@ -9,7 +9,7 @@ import toCoordinateFormat from './toCoordinateFormat.js'
  * Function for converting coordinates in a variety of formats to decimal coordinates
  * @param {string} coordsString The coordinates string to convert
  * @param {number} [decimalPlaces] The number of decimal places for converted coordinates; default is 5
- * @returns {object} { verbatimCoordinates, decimalCoordinates, decimalLatitude, decimalLongitude }
+ * @returns {{verbatimCoordinates: string, decimalCoordinates: string, decimalLatitude: string, decimalLongitude: string, closeEnough: function(string): boolean, toCoordinateFormat: toCoordinateFormat}}
  */
 function converter(coordsString, decimalPlaces) {
 

--- a/src/converter.js
+++ b/src/converter.js
@@ -8,7 +8,7 @@ import toCoordinateFormat from './toCoordinateFormat.js'
 /**
  * Function for converting coordinates in a variety of formats to decimal coordinates
  * @param {string} coordsString The coordinates string to convert
- * @param {number} decimalPlaces The number of decimal places for converted coordinates; default is 5
+ * @param {number} [decimalPlaces] The number of decimal places for converted coordinates; default is 5
  * @returns {object} { verbatimCoordinates, decimalCoordinates, decimalLatitude, decimalLongitude }
  */
 function converter(coordsString, decimalPlaces) {

--- a/src/toCoordinateFormat.js
+++ b/src/toCoordinateFormat.js
@@ -3,7 +3,8 @@
 
 /**
  * Converts decimalCoordinates to other formats commonly used
- * @param {*} format Either DMS or DM
+ * @param {string} format Either DMS or DM
+ * @returns {string}
  */
 function toCoordinateFormat(format) {
 


### PR DESCRIPTION
Hello,

As I was using this package with typescript I realized there is an error in the typescript definition of `convert` function : as per the `readme.md` and the function's code it can accept only one parameter but the typescript definition requires two parameters.

This pr fix the jsdoc that is used to generate the typescript definition to make second parameter optional.