### PR TITLE
Fix types

### DIFF
--- a/src/converter.js
+++ b/src/converter.js
@@ -9,7 +9,7 @@ import toCoordinateFormat from './toCoordinateFormat.js'
  * Function for converting coordinates in a variety of formats to decimal coordinates
  * @param {string} coordsString The coordinates string to convert
  * @param {number} [decimalPlaces] The number of decimal places for converted coordinates; default is 5
- * @returns {{verbatimCoordinates: string, decimalCoordinates: string, decimalLatitude: string, decimalLongitude: string, closeEnough: function(string): boolean, toCoordinateFormat: toCoordinateFormat}}
+ * @returns {{verbatimCoordinates: string, decimalCoordinates: string, decimalLatitude: number, decimalLongitude: number, closeEnough: function(string): boolean, toCoordinateFormat: toCoordinateFormat}}
  */
 function converter(coordsString, decimalPlaces) {
 


### PR DESCRIPTION
Hi, really handy library, thank you. I'm a typescript user and realized that the types defined are wrong as the 2 decimal coordinates are numbers, not string. Here is a proposed quick fix.

I'm not familiar with this build setup for types, but that's the only place I found anything in the form of type declarations, so hopefully it works.

Happy to iterate if needed.